### PR TITLE
[Bugfix] fix section title when sort items is selected

### DIFF
--- a/features/task/impl/src/main/java/wottrich/github/io/smartchecklist/domain/usecase/SortTasksBySelectedSortUseCase.kt
+++ b/features/task/impl/src/main/java/wottrich/github/io/smartchecklist/domain/usecase/SortTasksBySelectedSortUseCase.kt
@@ -29,10 +29,10 @@ class SortTasksBySelectedSortUseCase :
         val uncompletedTasks = tasksGroupedByIsCompleted[false].orEmpty()
         return when (selectedSort) {
             SortItemType.COMPLETED_TASKS -> {
-                completedTasks + BaseTaskListItem.SectionItem(R.string.task_sort_completed_task_item) + uncompletedTasks
+                completedTasks + BaseTaskListItem.SectionItem(R.string.task_sort_uncompleted_task_item) + uncompletedTasks
             }
             SortItemType.UNCOMPLETED_TASKS -> {
-                uncompletedTasks + BaseTaskListItem.SectionItem(R.string.task_sort_uncompleted_task_item) + completedTasks
+                uncompletedTasks + BaseTaskListItem.SectionItem(R.string.task_sort_completed_task_item) + completedTasks
             }
             SortItemType.UNSELECTED_SORT -> taskItems
         }

--- a/features/task/impl/src/test/kotlin/wottrich/github/io/smartchecklist/domain/usecase/SortTasksBySelectedSortUseCaseTest.kt
+++ b/features/task/impl/src/test/kotlin/wottrich/github/io/smartchecklist/domain/usecase/SortTasksBySelectedSortUseCaseTest.kt
@@ -41,8 +41,10 @@ class SortTasksBySelectedSortUseCaseTest : BaseUnitTest() {
             val result = sut(SortTasksBySelectedSortUseCase.Params(sortItems, tasks))
             val tasksSorted = result.getOrNull()
             val firstTask = tasksSorted!!.first()
+            val section: BaseTaskListItem.SectionItem = tasksSorted.firstOrNull { it is BaseTaskListItem.SectionItem } as BaseTaskListItem.SectionItem
             assertTrue(firstTask is BaseTaskListItem.TaskItem)
             assertFalse(firstTask.task.isCompleted)
+            assertEquals(section.sectionName, R.string.task_sort_completed_task_item)
         }
 
     @Test
@@ -53,8 +55,10 @@ class SortTasksBySelectedSortUseCaseTest : BaseUnitTest() {
             val tasksSorted =
                 sut(SortTasksBySelectedSortUseCase.Params(sortItems, tasks)).getOrNull()!!
             val firstTask = tasksSorted.first()
+            val section: BaseTaskListItem.SectionItem = tasksSorted.firstOrNull { it is BaseTaskListItem.SectionItem } as BaseTaskListItem.SectionItem
             assertTrue(firstTask is BaseTaskListItem.TaskItem)
             assertTrue(firstTask.task.isCompleted)
+            assertEquals(section.sectionName, R.string.task_sort_uncompleted_task_item)
         }
 
     private fun buildTaskUncompletedFirst(): List<NewTask> {


### PR DESCRIPTION
# Task to close

closes #92 

# Types of changes

[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Description, Motivation, and Context

The section title was incorrect when sort filter was selected.

# What is the destination branch of this PR?

Develop

# How Has This Been Tested?

Manual tests

# Screenshots (if appropriate):


https://github.com/Wottrich/android-smart-checklist/assets/24254062/304c774a-21c2-4ceb-9ee9-b128e30c60b8



# Checklist:

[x] I merged current develop to this branch.

[ ] My change requires a change to the documentation (confluence test paths, code style etc.)

[ ] I have updated the documentation accordingly.

[ ] My change requires a change to the UI tests.

[ ] I have updated UI test accordingly.

[x] I unit tested new methods.

[x] I checked linter on local.

[x] I checked unit tests on local.

---

## Is additional manual testing needed? 

No

## Files with major changes / what is worth paying more attention to? 

No

## Which variances have been affected

[x] DEBUG

[x] PROD

----

> Pull request template based on [Pull request template for the win!](https://medium.com/rsq-technologies/pull-request-template-for-the-win-a248ba91ad90) article
